### PR TITLE
Added RuntimeError to list of bugs catched by @retry... decorator

### DIFF
--- a/mindfultensors/mongoloader.py
+++ b/mindfultensors/mongoloader.py
@@ -141,6 +141,7 @@ class MongoheadDataset(MongoDataset):
                     except (
                         EOFError,
                         OperationFailure,
+                        RuntimeError,
                     ) as e:  # Specifically catching EOFError
                         if self.keeptrying:
                             if verbose:
@@ -158,7 +159,7 @@ class MongoheadDataset(MongoDataset):
 
         return decorator
 
-    @retry_on_eof_error(retry_count=3, verbose=True)
+    @retry_on_eof_error(retry_count=10, verbose=True)
     def __getitem__(self, batch):
         # Directly use the parent class's __getitem__ method
         # The decorator will handle exceptions


### PR DESCRIPTION
Dataset can sometimes panic if fetching corrupted data from mongodb and raises a RuntimeError
```
Traceback (most recent call last):
  File "/Users/mdoan4/work/wirehead/examples/unit/loader.py", line 11, in <module>
    data = dataset[idx]
  File "/Users/mdoan4/work/wirehead/wirehead/dataset.py", line 160, in wrapper
    return func(self, batch, *args, **kwargs)
  File "/Users/mdoan4/work/wirehead/wirehead/dataset.py", line 210, in __getitem__
    "input": self.normalize(self.transform(data).float()),
  File "/Users/mdoan4/work/wirehead/wirehead/dataset.py", line 29, in binary_to_tensor
    tensor = torch.load(buffer)
  File "/Users/mdoan4/work/wirehead/venv/lib/python3.10/site-packages/torch/serialization.py", line 1072, in load
    with _open_zipfile_reader(opened_file) as opened_zipfile:
  File "/Users/mdoan4/work/wirehead/venv/lib/python3.10/site-packages/torch/serialization.py", line 480, in __init__
    super().__init__(torch._C.PyTorchFileReader(name_or_buffer))
RuntimeError: PytorchStreamReader failed reading zip archive: invalid header or archive is corrupted
```
Also increased the retry count to 10. Running fetch on a loop on my laptop with wirehead can sometimes make it exceed the 3 retries consistently, likely due to lower latency with mongo.