### PR TITLE
Add unified single-collection MongoDataset with dtype based transform…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Scratch dev file — unified classes now live in mongoloader.py
+mindfultensors/mongoloader_unified.py
+
 # C extensions
 *.so
 

--- a/mindfultensors/__init__.py
+++ b/mindfultensors/__init__.py
@@ -1,0 +1,6 @@
+from .mongoloader import (
+    MongoDataset,
+    MongoheadDataset,
+    name2collection,
+    create_client,
+)

--- a/mindfultensors/mongoloader.py
+++ b/mindfultensors/mongoloader.py
@@ -16,11 +16,30 @@ from .utils import (
     DBBatchSampler,
 )
 
+
+# Named callables (not lambdas) so MongoDataset is picklable under
+# DataLoader(num_workers > 0) / multiprocessing spawn.
+def _as_long(x):
+    return torch.tensor(x, dtype=torch.long)
+
+
+def _as_float(x):
+    return torch.tensor(x, dtype=torch.float32)
+
+
+def _as_bool(x):
+    return torch.tensor(x, dtype=torch.bool)
+
+
+def _identity(x):
+    return x
+
+
 DEFAULT_TRANSFORMS = {
     "tensor": mtransform,
-    "int":    lambda x: torch.tensor(x, dtype=torch.long),
-    "float":  lambda x: torch.tensor(x, dtype=torch.float32),
-    "bool":   lambda x: torch.tensor(x, dtype=torch.bool),
+    "int": _as_long,
+    "float": _as_float,
+    "bool": _as_bool,
 }
 
 __all__ = [
@@ -56,7 +75,10 @@ class MongoDataset(Dataset):
         """Constructor
 
         :param indices: a set of indices to be extracted from the collection
-        :param collection: pymongo collection to be used
+        :param collection: pymongo collection to be used, or None. When None,
+            callers (e.g. DataLoader worker_init_fn / create_client) must attach
+            a live collection before __getitem__. Pass a collection at init only
+            to create indexes, then clear it before pickling into workers.
         :param fetch: a tuple of kind names to be fetched, e.g. (`smri`, `gender_encoded`). Supports both chunk kinds (tensors) and scalar kinds (single value docs)
         :param transforms: optional dict mapping dtype strings to transform functions, e.g. `{"int": lambda x: torch.tensor(x, dtype=torch.long)}`. Overrides DEFAULT_TRANSFORMS for the specified dtype.
         :param normalize: a function to be applied to each tensor kind after transform
@@ -76,7 +98,11 @@ class MongoDataset(Dataset):
         self.fields = fields or {}
         self.id = id
 
-        collection.create_index([(id, 1), ("kind", 1)])
+        # Match main's convention: collection may be None at construction /
+        # pickle time; workers attach a client via create_client. Only index
+        # when a live collection was provided.
+        if collection is not None:
+            collection.create_index([(id, 1), ("kind", 1)])
 
     def __len__(self):
         return len(self.indices)
@@ -108,9 +134,13 @@ class MongoDataset(Dataset):
             for kind in self.fetch:
                 kind_docs = grouped.get((subject_id, kind), [])
                 if not kind_docs:
-                    continue
+                    # Don't return a partial dict (breaks mcollate). Raise so
+                    # MongoheadDataset's retry can ride out wirehead swaps.
+                    raise RuntimeError(
+                        f"missing kind {kind!r} for {self.id}={subject_id}"
+                    )
                 dtype = kind_docs[0]["dtype"]
-                t = self.transforms.get(dtype, lambda x: x)
+                t = self.transforms.get(dtype, _identity)
                 if dtype == "tensor":
                     binary = self.make_serial(kind_docs)
                     results[idx][kind] = self.normalize(t(binary).float())

--- a/mindfultensors/mongoloader.py
+++ b/mindfultensors/mongoloader.py
@@ -1,3 +1,4 @@
+import torch
 from pymongo import MongoClient
 from torch.utils.data import Dataset, get_worker_info
 from torch.utils.data.sampler import Sampler
@@ -15,6 +16,13 @@ from .utils import (
     DBBatchSampler,
 )
 
+DEFAULT_TRANSFORMS = {
+    "tensor": mtransform,
+    "int":    lambda x: torch.tensor(x, dtype=torch.long),
+    "float":  lambda x: torch.tensor(x, dtype=torch.float32),
+    "bool":   lambda x: torch.tensor(x, dtype=torch.bool),
+}
+
 __all__ = [
     "unit_interval_normalize",
     "qnormalize",
@@ -23,93 +31,91 @@ __all__ = [
     "collate_subcubes",
     "subcube_list",
     "MongoDataset",
+    "MongoheadDataset",
+    "name2collection",
+    "create_client",
     "DBBatchSampler",
 ]
 
 
 class MongoDataset(Dataset):
     """
-    A dataset for fetching batches of records from a MongoDB
+    A dataset for fetching batches of records from a single MongoDB collection
     """
 
     def __init__(
         self,
         indices,
-        transform,
         collection,
-        sample,
+        fetch,
+        transforms=None,
         normalize=unit_interval_normalize,
+        fields=None,
         id="id",
     ):
         """Constructor
 
         :param indices: a set of indices to be extracted from the collection
-        :param transform: a function to be applied to each extracted record
         :param collection: pymongo collection to be used
-        :param sample: a pair of fields to be fetched as `input` and `label`, e.g. (`T1`, `label104`)
+        :param fetch: a tuple of kind names to be fetched, e.g. (`smri`, `gender_encoded`). Supports both chunk kinds (tensors) and scalar kinds (single value docs)
+        :param transforms: optional dict mapping dtype strings to transform functions, e.g. `{"int": lambda x: torch.tensor(x, dtype=torch.long)}`. Overrides DEFAULT_TRANSFORMS for the specified dtype.
+        :param normalize: a function to be applied to each tensor kind after transform
+        :param fields: optional MongoDB projection dict, e.g. `{"id": 1, "kind": 1, "chunk": 1}`. Fetches all fields if not specified.
         :param id: the field to be used as an index. The `indices` are values of this field
         :returns: an object of MongoDataset class
 
         """
+        if not fetch:
+            raise ValueError("fetch must be a non-empty tuple of kind names")
 
         self.indices = indices
-        self.transform = transform
         self.collection = collection
-        # self.fields = {_: 1 for _ in self.fields} if fields is not None else {}
-        self.fields = {"id": 1, "chunk": 1, "kind": 1, "chunk_id": 1}
-        self.sample = sample
+        self.fetch = tuple(fetch)
+        self.transforms = {**DEFAULT_TRANSFORMS, **(transforms or {})}
         self.normalize = normalize
+        self.fields = fields or {}
         self.id = id
+
+        collection.create_index([(id, 1), ("kind", 1)])
 
     def __len__(self):
         return len(self.indices)
 
-    def make_serial(self, samples_for_id, kind):
-        return b"".join(
-            [
-                sample["chunk"]
-                for sample in sorted(
-                    (
-                        sample
-                        for sample in samples_for_id
-                        if sample["kind"] == kind
-                    ),
-                    key=lambda x: x["chunk_id"],
-                )
-            ]
-        )
+    def make_serial(self, kind_docs):
+        ordered = [None] * len(kind_docs)
+        for doc in kind_docs:
+            ordered[doc["chunk_id"]] = doc["chunk"]
+        return b"".join(ordered)
 
     def __getitem__(self, batch):
-        # Fetch all samples for ids in the batch and where 'kind' is either
-        # data or label as specified by the sample parameter
-        samples = list(
-            self.collection["bin"].find(
-                {
-                    self.id: {"$in": [self.indices[_] for _ in batch]},
-                    "kind": {"$in": self.sample},
-                },
-                self.fields,
-            )
-        )
+        batch_ids = [self.indices[i] for i in batch]
+        docs = list(self.collection.find(
+            {self.id: {"$in": batch_ids}, "kind": {"$in": list(self.fetch)}},
+            self.fields or None,
+        ))
+
+        grouped = {}
+        for doc in docs:
+            key = (doc[self.id], doc["kind"])
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(doc)
 
         results = {}
-        for id in batch:
-            # Separate samples for this id
-            samples_for_id = [
-                sample
-                for sample in samples
-                if sample[self.id] == self.indices[id]
-            ]
-
-            # Separate processing for each 'kind'
-            data = self.make_serial(samples_for_id, self.sample[0])
-            label = self.make_serial(samples_for_id, self.sample[1])
-
-            # Add to results
-            results[id] = {
-                "input": self.normalize(self.transform(data).float()),
-                "label": self.transform(label),
-            }
+        for idx in batch:
+            subject_id = self.indices[idx]
+            results[idx] = {}
+            for kind in self.fetch:
+                kind_docs = grouped.get((subject_id, kind), [])
+                if not kind_docs:
+                    continue
+                dtype = kind_docs[0]["dtype"]
+                t = self.transforms.get(dtype, lambda x: x)
+                if dtype == "tensor":
+                    binary = self.make_serial(kind_docs)
+                    results[idx][kind] = self.normalize(t(binary).float())
+                else:
+                    results[idx][kind] = t(kind_docs[0]["value"])
 
         return results
 
@@ -119,15 +125,14 @@ class MongoheadDataset(MongoDataset):
         """Constructor
 
         :param indices: a set of indices to be extracted from the collection
-        :param transform: a function to be applied to each extracted record
         :param collection: pymongo collection to be used
-        :param sample: a pair of fields to be fetched as `input` and `label`, e.g. (`T1`, `label104`)
+        :param fetch: a tuple of kind names to be fetched, e.g. (`smri`, `gender_encoded`)
+        :param transforms: optional dict mapping dtype strings to transform functions
         :param id: the field to be used as an index. The `indices` are values of this field
         :param keeptrying: whether to keep retrying to fetch a record if the process failed or just report this and fail
-        :returns: an object of MongoDataset class
+        :returns: an object of MongoheadDataset class
 
         """
-
         super().__init__(*args, **kwargs)
         self.keeptrying = keeptrying  # Initialize the keeptrying attribute
 
@@ -166,15 +171,12 @@ class MongoheadDataset(MongoDataset):
         return super().__getitem__(batch)
 
 
-def name2collections(name: str, database):
-    collection_bin = database[f"{name}.bin"]
-    collection_meta = database[f"{name}.meta"]
-    return collection_bin, collection_meta
+def name2collection(name, database):
+    return database[name]
 
 
 def create_client(worker_id, dbname, colname, mongohost):
     worker_info = get_worker_info()
     dataset = worker_info.dataset
     client = MongoClient("mongodb://" + mongohost + ":27017")
-    colbin, colmeta = name2collections(colname, client[dbname])
-    dataset.collection = {"bin": colbin, "meta": colmeta}
+    dataset.collection = name2collection(colname, client[dbname])

--- a/mindfultensors/mongoloader.py
+++ b/mindfultensors/mongoloader.py
@@ -36,7 +36,7 @@ def _identity(x):
 
 
 DEFAULT_TRANSFORMS = {
-    "tensor": mtransform,
+    "tensor": mtransform,   # deserializes a tensor kind's chunk bytes; fetched by the fixed "tensor" slot, not by a doc's normative dtype
     "int": _as_long,
     "float": _as_float,
     "bool": _as_bool,
@@ -80,8 +80,8 @@ class MongoDataset(Dataset):
             a live collection before __getitem__. Pass a collection at init only
             to create indexes, then clear it before pickling into workers.
         :param fetch: a tuple of kind names to be fetched, e.g. (`smri`, `gender_encoded`). Supports both chunk kinds (tensors) and scalar kinds (single value docs)
-        :param transforms: optional dict mapping dtype strings to transform functions, e.g. `{"int": lambda x: torch.tensor(x, dtype=torch.long)}`. Overrides DEFAULT_TRANSFORMS for the specified dtype.
-        :param normalize: a function to be applied to each tensor kind after transform
+        :param transforms: optional dict overriding DEFAULT_TRANSFORMS. Holds the `"tensor"` decoder (chunk bytes -> tensor) plus per-dtype scalar transforms, e.g. `{"int": lambda x: torch.tensor(x, dtype=torch.long)}`. Tensor kinds fetch the fixed `"tensor"` slot; scalar kinds are looked up by their dtype.
+        :param normalize: a function to be applied to each non-label tensor kind after transform
         :param fields: optional MongoDB projection dict, e.g. `{"id": 1, "kind": 1, "chunk": 1}`. Fetches all fields if not specified.
         :param id: the field to be used as an index. The `indices` are values of this field
         :returns: an object of MongoDataset class
@@ -139,13 +139,17 @@ class MongoDataset(Dataset):
                     raise RuntimeError(
                         f"missing kind {kind!r} for {self.id}={subject_id}"
                     )
-                dtype = kind_docs[0]["dtype"]
-                t = self.transforms.get(dtype, _identity)
-                if dtype == "tensor":
-                    binary = self.make_serial(kind_docs)
-                    results[idx][kind] = self.normalize(t(binary).float())
+                first = kind_docs[0]
+                if "chunk" in first:
+                    # dtype is normative: "long" -> label (cast, no normalize); else -> input (cast to float, normalize)
+                    tensor = self.transforms["tensor"](self.make_serial(kind_docs))
+                    if first["dtype"] == "long":
+                        results[idx][kind] = tensor.long()
+                    else:
+                        results[idx][kind] = self.normalize(tensor.float())
                 else:
-                    results[idx][kind] = t(kind_docs[0]["value"])
+                    t = self.transforms.get(first["dtype"], _identity)
+                    results[idx][kind] = t(first["value"])
 
         return results
 

--- a/mindfultensors/utils.py
+++ b/mindfultensors/utils.py
@@ -39,16 +39,20 @@ def tensor2bin(tensor):
     return buffer.getvalue()
 
 
-def build_kind_docs(subject_id, kind, value, id_field="id", chunk_size_mb=10):
+def build_kind_docs(subject_id, kind, value, dtype, id_field="id", chunk_size_mb=10):
     """Build the doc(s) for one kind (tensor or scalar), without touching the database.
 
     :param subject_id: the subject's index value, stored under `id_field`
-    :param kind: the kind name, e.g. `smri` or `age`
+    :param kind: the kind name, e.g. `smri` or `label3`
     :param value: a tensor (chunked and stored as binary) or a scalar (int/float/bool)
+    :param dtype: required, caller-declared, never inferred. Tensors: "long"=label (no normalize), else=input (cast float32, normalize). Scalars: selects the transform ("int"/"float"/"bool"/"str").
     :param id_field: the field name to store subject_id under
     :param chunk_size_mb: chunk size in MB for tensor kinds
     :returns: a list of docs ready to be inserted, e.g. via `insert_many`/`insert_one`
     """
+    if dtype is None:
+        raise ValueError(f"kind {kind!r} requires an explicit dtype")
+
     if torch.is_tensor(value):
         binary           = tensor2bin(value)
         chunk_size_bytes = chunk_size_mb * 1024 * 1024
@@ -60,7 +64,7 @@ def build_kind_docs(subject_id, kind, value, id_field="id", chunk_size_mb=10):
             docs.append({
                 id_field:   subject_id,
                 "kind":     kind,
-                "dtype":    "tensor",
+                "dtype":    dtype,
                 "chunk_id": chunk_id,
                 "chunk":    bson.Binary(binary[start:end]),
             })
@@ -69,22 +73,23 @@ def build_kind_docs(subject_id, kind, value, id_field="id", chunk_size_mb=10):
     return [{
         id_field: subject_id,
         "kind":   kind,
-        "dtype":  type(value).__name__,
+        "dtype":  dtype,
         "value":  value,
     }]
 
 
-def insert_kind(collection, subject_id, kind, value, id_field="id", chunk_size_mb=10):
+def insert_kind(collection, subject_id, kind, value, dtype, id_field="id", chunk_size_mb=10):
     """Insert a kind (tensor or scalar) into a unified collection.
 
     :param collection: pymongo collection to insert into
     :param subject_id: the subject's index value, stored under `id_field`
-    :param kind: the kind name, e.g. `smri` or `age`
+    :param kind: the kind name, e.g. `smri` or `label3`
     :param value: a tensor (chunked and stored as binary) or a scalar (int/float/bool)
+    :param dtype: required, always caller-declared. Tensor kinds: `"long"` for a label, e.g. `"f32"` for an input. Scalar kinds: `"int"`/`"float"`/`"bool"`/`"str"`. See `build_kind_docs`.
     :param id_field: the field name to store subject_id under
     :param chunk_size_mb: chunk size in MB for tensor kinds
     """
-    docs = build_kind_docs(subject_id, kind, value, id_field, chunk_size_mb)
+    docs = build_kind_docs(subject_id, kind, value, dtype, id_field, chunk_size_mb)
     if torch.is_tensor(value):
         collection.insert_many(docs)
     else:

--- a/mindfultensors/utils.py
+++ b/mindfultensors/utils.py
@@ -39,6 +39,41 @@ def tensor2bin(tensor):
     return buffer.getvalue()
 
 
+def build_kind_docs(subject_id, kind, value, id_field="id", chunk_size_mb=10):
+    """Build the doc(s) for one kind (tensor or scalar), without touching the database.
+
+    :param subject_id: the subject's index value, stored under `id_field`
+    :param kind: the kind name, e.g. `smri` or `age`
+    :param value: a tensor (chunked and stored as binary) or a scalar (int/float/bool)
+    :param id_field: the field name to store subject_id under
+    :param chunk_size_mb: chunk size in MB for tensor kinds
+    :returns: a list of docs ready to be inserted, e.g. via `insert_many`/`insert_one`
+    """
+    if torch.is_tensor(value):
+        binary           = tensor2bin(value)
+        chunk_size_bytes = chunk_size_mb * 1024 * 1024
+        num_chunks       = (len(binary) + chunk_size_bytes - 1) // chunk_size_bytes
+        docs = []
+        for chunk_id in range(num_chunks):
+            start = chunk_id * chunk_size_bytes
+            end   = min(start + chunk_size_bytes, len(binary))
+            docs.append({
+                id_field:   subject_id,
+                "kind":     kind,
+                "dtype":    "tensor",
+                "chunk_id": chunk_id,
+                "chunk":    bson.Binary(binary[start:end]),
+            })
+        return docs
+
+    return [{
+        id_field: subject_id,
+        "kind":   kind,
+        "dtype":  type(value).__name__,
+        "value":  value,
+    }]
+
+
 def insert_kind(collection, subject_id, kind, value, id_field="id", chunk_size_mb=10):
     """Insert a kind (tensor or scalar) into a unified collection.
 
@@ -49,33 +84,11 @@ def insert_kind(collection, subject_id, kind, value, id_field="id", chunk_size_m
     :param id_field: the field name to store subject_id under
     :param chunk_size_mb: chunk size in MB for tensor kinds
     """
+    docs = build_kind_docs(subject_id, kind, value, id_field, chunk_size_mb)
     if torch.is_tensor(value):
-        _insert_tensor_kind(collection, subject_id, kind, value, id_field, chunk_size_mb)
+        collection.insert_many(docs)
     else:
-        collection.insert_one({
-            id_field: subject_id,
-            "kind":   kind,
-            "dtype":  type(value).__name__,
-            "value":  value,
-        })
-
-
-def _insert_tensor_kind(collection, subject_id, kind, tensor, id_field, chunk_size_mb):
-    binary           = tensor2bin(tensor)
-    chunk_size_bytes = chunk_size_mb * 1024 * 1024
-    num_chunks       = (len(binary) + chunk_size_bytes - 1) // chunk_size_bytes
-    docs = []
-    for chunk_id in range(num_chunks):
-        start = chunk_id * chunk_size_bytes
-        end   = min(start + chunk_size_bytes, len(binary))
-        docs.append({
-            id_field:   subject_id,
-            "kind":     kind,
-            "dtype":    "tensor",
-            "chunk_id": chunk_id,
-            "chunk":    bson.Binary(binary[start:end]),
-        })
-    collection.insert_many(docs)
+        collection.insert_one(docs[0])
 
 
 def mcollate(results, field=("input", "label")):

--- a/mindfultensors/utils.py
+++ b/mindfultensors/utils.py
@@ -1,6 +1,7 @@
 import lz4.frame
 import torch
 import io
+import bson
 import numpy as np
 from typing import Sized
 from torch.utils.data.sampler import Sampler
@@ -29,6 +30,52 @@ def mtransform(tensor_binary):
     buffer = io.BytesIO(tensor_binary)
     tensor = torch.load(buffer, weights_only=True)
     return tensor
+
+
+def tensor2bin(tensor):
+    """Serialize a tensor to a binary blob."""
+    buffer = io.BytesIO()
+    torch.save(tensor, buffer)
+    return buffer.getvalue()
+
+
+def insert_kind(collection, subject_id, kind, value, id_field="id", chunk_size_mb=10):
+    """Insert a kind (tensor or scalar) into a unified collection.
+
+    :param collection: pymongo collection to insert into
+    :param subject_id: the subject's index value, stored under `id_field`
+    :param kind: the kind name, e.g. `smri` or `age`
+    :param value: a tensor (chunked and stored as binary) or a scalar (int/float/bool)
+    :param id_field: the field name to store subject_id under
+    :param chunk_size_mb: chunk size in MB for tensor kinds
+    """
+    if torch.is_tensor(value):
+        _insert_tensor_kind(collection, subject_id, kind, value, id_field, chunk_size_mb)
+    else:
+        collection.insert_one({
+            id_field: subject_id,
+            "kind":   kind,
+            "dtype":  type(value).__name__,
+            "value":  value,
+        })
+
+
+def _insert_tensor_kind(collection, subject_id, kind, tensor, id_field, chunk_size_mb):
+    binary           = tensor2bin(tensor)
+    chunk_size_bytes = chunk_size_mb * 1024 * 1024
+    num_chunks       = (len(binary) + chunk_size_bytes - 1) // chunk_size_bytes
+    docs = []
+    for chunk_id in range(num_chunks):
+        start = chunk_id * chunk_size_bytes
+        end   = min(start + chunk_size_bytes, len(binary))
+        docs.append({
+            id_field:   subject_id,
+            "kind":     kind,
+            "dtype":    "tensor",
+            "chunk_id": chunk_id,
+            "chunk":    bson.Binary(binary[start:end]),
+        })
+    collection.insert_many(docs)
 
 
 def mcollate(results, field=("input", "label")):

--- a/scripts/simulate_usage.py
+++ b/scripts/simulate_usage.py
@@ -1,0 +1,139 @@
+import torch
+from pymongo import MongoClient
+from torch.utils.data import DataLoader
+
+from mindfultensors.mongoloader import (
+    MongoDataset,
+    create_client,
+    name2collection,
+)
+from mindfultensors.utils import insert_kind, unit_interval_normalize, DBBatchSampler
+
+# -----------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------
+
+MONGOHOST  = "localhost"
+DBNAME     = "mindfultensors_sim"
+COLLECTION = "sim_unified"
+INDEX_ID   = "id"
+NUM_SUBJECTS = 4
+CHUNK_SIZE   = 1  # MB
+
+# -----------------------------------------------------------------------
+# Simulated subjects — fixed values for reproducibility
+# Each subject has:
+#   smri       — 3D tensor (8x8x8), tensor kind
+#   falff      — 3D tensor (8x8x8), tensor kind
+#   age        — float scalar
+#   gender     — int scalar (0=M, 1=F)
+#   site       — str scalar
+#   is_control — bool scalar
+# -----------------------------------------------------------------------
+
+SUBJECTS = [
+    {"id": 0, "age": 24.0, "gender": 0, "site": "site_A", "is_control": True},
+    {"id": 1, "age": 31.0, "gender": 1, "site": "site_B", "is_control": False},
+    {"id": 2, "age": 27.0, "gender": 0, "site": "site_A", "is_control": True},
+    {"id": 3, "age": 45.0, "gender": 1, "site": "site_C", "is_control": False},
+]
+
+# -----------------------------------------------------------------------
+# Populate: simulated data -> unified collection
+# -----------------------------------------------------------------------
+
+def populate(db):
+    col = db[COLLECTION]
+    col.drop()
+
+    for subject in SUBJECTS:
+        sid = subject["id"]
+        print(f"  inserting subject {sid}")
+
+        torch.manual_seed(sid)
+        insert_kind(col, sid, "smri",       torch.rand(8, 8, 8), id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
+        insert_kind(col, sid, "falff",      torch.rand(8, 8, 8), id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
+        insert_kind(col, sid, "age",        subject["age"],        id_field=INDEX_ID)
+        insert_kind(col, sid, "gender",     subject["gender"],     id_field=INDEX_ID)
+        insert_kind(col, sid, "site",       subject["site"],       id_field=INDEX_ID)
+        insert_kind(col, sid, "is_control", subject["is_control"], id_field=INDEX_ID)
+
+    col.create_index([(INDEX_ID, 1), ("kind", 1)])
+    print(f"done. total docs: {col.count_documents({})}")
+
+
+# -----------------------------------------------------------------------
+# Dataset + DataLoader
+# -----------------------------------------------------------------------
+
+client = MongoClient("mongodb://" + MONGOHOST + ":27017")
+db     = client[DBNAME]
+col    = name2collection(COLLECTION, db)
+
+
+dataset = MongoDataset(
+    indices    = [s["id"] for s in SUBJECTS],
+    collection = col,
+    fetch      = ("smri", "falff", "age", "gender", "is_control"),
+    normalize  = unit_interval_normalize,
+    id         = INDEX_ID,
+)
+
+
+def collate(results):
+    results = results[0]
+
+    print(f"\n--- before collate ---")
+    for kind in next(iter(results.values())).keys():
+        values = [results[i][kind] for i in results]
+        if hasattr(values[0], "shape"):
+            print(f"  {kind}: [{', '.join(str(v.shape) for v in values)}]")
+        else:
+            print(f"  {kind}: {values}")
+
+    smri   = torch.stack([results[i]["smri"]  for i in results]).unsqueeze(1)
+    falff  = torch.stack([results[i]["falff"] for i in results]).unsqueeze(1)
+    age    = [results[i]["age"]        for i in results]
+    gender = [results[i]["gender"]     for i in results]
+    ctrl   = [results[i]["is_control"] for i in results]
+
+    return {"smri": smri, "falff": falff, "age": age, "gender": gender, "is_control": ctrl}
+
+
+def worker_init(worker_id):
+    create_client(
+        worker_id, dbname=DBNAME, colname=COLLECTION, mongohost=MONGOHOST
+    )
+
+
+dataloader = DataLoader(
+    dataset,
+    sampler    = DBBatchSampler(dataset, batch_size=2, seed=42),
+    collate_fn = collate,
+    num_workers = 0,
+)
+
+
+# -----------------------------------------------------------------------
+# Entry point
+# -----------------------------------------------------------------------
+
+if __name__ == "__main__":
+    populate(db)
+
+    print("\ncollection state before fetching:")
+    for doc in col.find({}, {"_id": 0}):
+        if "chunk" in doc:
+            print(f"  {{id: {doc['id']}, kind: \"{doc['kind']}\", chunk_id: {doc['chunk_id']}, chunk: <Binary {len(doc['chunk'])} bytes>}}")
+        else:
+            print(f"  {{id: {doc['id']}, kind: \"{doc['kind']}\", value: {repr(doc['value'])}}}")
+
+    print("\nsmoke test — fetching one batch ...")
+    for batch in dataloader:
+        print(f"\n--- batch ---")
+        print(f"  smri       : {batch['smri'].shape}")
+        print(f"  falff      : {batch['falff'].shape}")
+        print(f"  age        : {batch['age']}")
+        print(f"  gender     : {batch['gender']}")
+        print(f"  is_control : {batch['is_control']}")
+        break

--- a/scripts/simulate_usage.py
+++ b/scripts/simulate_usage.py
@@ -51,12 +51,12 @@ def populate(db):
         print(f"  inserting subject {sid}")
 
         torch.manual_seed(sid)
-        insert_kind(col, sid, "smri",       torch.rand(8, 8, 8), id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
-        insert_kind(col, sid, "falff",      torch.rand(8, 8, 8), id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
-        insert_kind(col, sid, "age",        subject["age"],        id_field=INDEX_ID)
-        insert_kind(col, sid, "gender",     subject["gender"],     id_field=INDEX_ID)
-        insert_kind(col, sid, "site",       subject["site"],       id_field=INDEX_ID)
-        insert_kind(col, sid, "is_control", subject["is_control"], id_field=INDEX_ID)
+        insert_kind(col, sid, "smri",       torch.rand(8, 8, 8), dtype="f32", id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
+        insert_kind(col, sid, "falff",      torch.rand(8, 8, 8), dtype="f32", id_field=INDEX_ID, chunk_size_mb=CHUNK_SIZE)
+        insert_kind(col, sid, "age",        subject["age"],        dtype="float", id_field=INDEX_ID)
+        insert_kind(col, sid, "gender",     subject["gender"],     dtype="int",   id_field=INDEX_ID)
+        insert_kind(col, sid, "site",       subject["site"],       dtype="str",   id_field=INDEX_ID)
+        insert_kind(col, sid, "is_control", subject["is_control"], dtype="bool",  id_field=INDEX_ID)
 
     col.create_index([(INDEX_ID, 1), ("kind", 1)])
     print(f"done. total docs: {col.count_documents({})}")


### PR DESCRIPTION
- Replace two-collection (.bin/.meta) `MongoDataset` with a single unified collection, every tensor modality and label (tensor or scalar) is stored as a kind in one collection.
- `__getitem__ `fetches all kinds in one query and dispatches transforms by dtype (tensor, int, float, bool), defaulting to explicit torch.long/float32/bool tensors.
- Add insert_kind helper `utils.py` to populate either tensor or scalar kinds with one call.
- A `usage/simulate_usage.py` script to demonstrate the new architecture.